### PR TITLE
feat: add wp/db tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+allure-results
+allure-report
+
+### IntelliJ IDEA ###
+.idea
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 Back Autotests
+
+Структура проекта:
+- test/java/tests - автотесты
+- test/java/utils - утильные классы
+- test/java/pojo/ - pojo-объекты
+- test/java/TestCases.txt - тест-кейсы

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>BA</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>20</maven.compiler.source>
+        <maven.compiler.target>20</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <aspectjweaver-version>1.9.19</aspectjweaver-version>
+        <allure-junit5-version>2.22.0</allure-junit5-version>
+        <maven-resources-plugin-version>3.3.1</maven-resources-plugin-version>
+        <maven-compiler-plugin-version>3.11.0</maven-compiler-plugin-version>
+        <maven-surefire-plugin-version>3.1.0</maven-surefire-plugin-version>
+        <junit-jupiter-version>5.10.0-M1</junit-jupiter-version>
+    </properties>
+
+    <dependencies>
+
+        <!-- https://mvnrepository.com/artifact/com.mysql/mysql-connector-j -->
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.0.33</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.7</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.0-M1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.0-rc2</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/io.rest-assured/rest-assured -->
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>5.3.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.json/json -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20230227</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjweaver</artifactId>
+            <version>${aspectjweaver-version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.qameta.allure</groupId>
+            <artifactId>allure-junit5</artifactId>
+            <version>${allure-junit5-version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit-jupiter-version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.aeonbits.owner/owner -->
+        <dependency>
+            <groupId>org.aeonbits.owner</groupId>
+            <artifactId>owner</artifactId>
+            <version>1.0.12</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.28</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/io.qameta.allure/allure-rest-assured -->
+        <dependency>
+            <groupId>io.qameta.allure</groupId>
+            <artifactId>allure-rest-assured</artifactId>
+            <version>${allure-junit5-version}</version>
+        </dependency>
+
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${maven-resources-plugin-version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin-version}</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.28</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin-version}</version>
+                <configuration>
+                    <rerunFailingTestsCount>2</rerunFailingTestsCount>
+                    <includes>
+                        <include>*/**</include>
+                    </includes>
+                    <testFailureIgnore>false</testFailureIgnore>
+                    <argLine>
+                        -javaagent:"${settings.localRepository}/org/aspectj/aspectjweaver/${aspectjweaver-version}/aspectjweaver-${aspectjweaver-version}.jar"
+                        -Dcucumber.plugin="pretty, io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm"
+                    </argLine>
+                    <systemPropertyVariables>
+                        <property>
+                            <name>junit.jupiter.extensions.autodetection.enabled</name>
+                            <value>true</value>
+                        </property>
+                    </systemPropertyVariables>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.aspectj</groupId>
+                        <artifactId>aspectjweaver</artifactId>
+                        <version>${aspectjweaver-version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>io.qameta.allure</groupId>
+                <artifactId>allure-maven</artifactId>
+                <version>2.12.0</version>
+                <configuration>
+                    <allureDownloadUrl>https://github.com/allure-framework/allure2/releases/download/${allure-junit5-version}/allure-${allure-junit5-version}.zip</allureDownloadUrl>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.2.2</version>
+                <configuration>
+                    <includeTestResources>true</includeTestResources>
+                    <sourceDirectories>src/</sourceDirectories>
+                    <configLocation>sun_checks_config.xml</configLocation>
+                </configuration>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>checkstyle</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
+
+</project>

--- a/src/test/java/TestCasec.txt
+++ b/src/test/java/TestCasec.txt
@@ -1,0 +1,72 @@
+id: createWpPost
+Заголовок: создать пост
+Шаги:
+1. отправить POST-запрос на /wp/v2/posts, установив query-параметры title - createPostTitle, content - createPostContent, status - publish
+Ожидаемый результат:
+1. код ответа равен 201
+2. тело ответа в формате JSON возращается от сервера и имеет следующий вид (... - любые ключи/значения, перечисленные ключи являются обязательными):
+{
+    "id": ...,
+    ...
+    "status": "publish",
+    "title": {
+        ...
+        "rendered": "createPostTitle"
+    },
+    "content": {
+        ...
+        "rendered": "<p>createPostContent</p>\n",
+    },
+    ...
+}
+3. в таблице wp_posts (БД - wordpress) появилась запись, содержащая post_title "createPostTitle", post_content "createPostContent", status "publish"
+
+id: changeWpPostTitle
+Заголовок: изменить заголовок поста
+Предусловие:
+1. отправить POST-запрос на /wp/v2/posts, установив query-параметры title - createPostTitle, content - createPostContent, status - publish
+Шаги:
+1. отправить PATCH-запрос на /wp/v2/posts/{postId} (postId - ID поста, созданного в предусловии), передав в body запроса title - New Title
+Ожидаемый результат:
+1. код ответа равен 200
+2. тело ответа в формате JSON возращается от сервера и имеет следующий вид (... - любые ключи/значения, перечисленные ключи являются обязательными):
+{
+    "id": {postId},
+    ...
+    "status": "publish",
+    "title": {
+        ...
+        "rendered": "New Title"
+    },
+    "content": {
+        ...
+        "rendered": <p>createPostContent</p>\n",
+    },
+    ...
+}
+3. в таблице wp_posts (БД - wordpress)  появилась и обновилась запись, содержащая (после обновления) post_title "New Title", post_content "createPostContent"
+
+id: deleteWpPost
+Заголовок: удалить пост
+Предусловие:
+1. отправить POST-запрос на /wp/v2/posts, установив query-параметры title - createPostTitle, content - createPostContent, status - publish
+Шаги:
+1. отправить DELETE-запрос на /wp/v2/posts/{postId} (postId - ID поста, созданного в предусловии)
+Ожидаемый результат:
+1. код ответа равен 200
+2. тело ответа в формате JSON возращается от сервера и имеет следующий вид (... - любые ключи/значения, перечисленные ключи являются обязательными):
+{
+    "id": {postId},
+    ...
+    "status": "trash",
+    "title": {
+        ...
+        "rendered": "createPostTitle"
+    },
+    "content": {
+        ...
+        "rendered": "<p>createPostContent</p>\n",
+    },
+    ...
+}
+3. в таблице wp_posts (БД - wordpress)  появилась и обновилась запись, содержащая (после обновления) post_title "createPostTitle, status "trash"

--- a/src/test/java/db/DataBaseManager.java
+++ b/src/test/java/db/DataBaseManager.java
@@ -1,0 +1,61 @@
+package db;
+
+import pojo.Posts;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static utils.DataBaseConnection.createConnection;
+
+/**
+ * The type Posts utils.
+ */
+public final class DataBaseManager {
+
+    /**
+     * Gets posts.
+     * @param id the id
+     * @return Posts
+     * @throws SQLException the sql exception
+     */
+    public static List<Posts> getPostDataFromDB(final int id) throws SQLException {
+        ResultSet resultSet = null;
+        List<Posts> list = new ArrayList<Posts>();
+        String query = "SELECT * FROM wp_posts WHERE ID = ?";
+        Posts posts;
+        try (PreparedStatement statement = createConnection().prepareStatement(query)) {
+            statement.setInt(1, id);
+            resultSet = statement.executeQuery();
+            while (resultSet.next()) {
+                posts = new Posts();
+                posts.setId(resultSet.getString("id"));
+                posts.setStatus(resultSet.getString("post_status"));
+                posts.setPostContent(resultSet.getString("post_content"));
+                posts.setPostTitle(resultSet.getString("post_title"));
+                list.add(posts);
+            }
+        } finally {
+            assert resultSet != null;
+            resultSet.close();
+            createConnection().close();
+        }
+        return list;
+    }
+
+    /**
+     * Gets posts.
+     * @param id the id
+     * @return Posts
+     * @throws SQLException the sql exception
+     */
+    public static Posts getPost(final int id) throws SQLException {
+        return getPostDataFromDB(id).get(0);
+    }
+
+    private DataBaseManager() {
+        throw new IllegalStateException("Utility class");
+    }
+}

--- a/src/test/java/pojo/Content.java
+++ b/src/test/java/pojo/Content.java
@@ -1,0 +1,17 @@
+package pojo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+/**
+ * The type Content.
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Content {
+
+    /**
+     * Field - rendered.
+     */
+    private String rendered;
+}

--- a/src/test/java/pojo/Posts.java
+++ b/src/test/java/pojo/Posts.java
@@ -1,0 +1,35 @@
+package pojo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+/**
+ * The type Posts.
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Posts {
+
+    /**
+     * Field - id.
+     */
+    private String id;
+
+    /**
+     * Field - status.
+     */
+    private String status;
+
+    /**
+     * Field - postTitle.
+     */
+    @JsonProperty("post_title")
+    private String postTitle;
+
+    /**
+     * Field - postContent.
+     */
+    @JsonProperty("post_content")
+    private String postContent;
+}

--- a/src/test/java/pojo/Title.java
+++ b/src/test/java/pojo/Title.java
@@ -1,0 +1,17 @@
+package pojo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+/**
+ * The type Title.
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Title {
+
+    /**
+     * Field - rendered.
+     */
+    private String rendered;
+}

--- a/src/test/java/props/Configuration.java
+++ b/src/test/java/props/Configuration.java
@@ -1,0 +1,57 @@
+package props;
+
+import org.aeonbits.owner.Config;
+
+/**
+ * The interface Configuration.
+ */
+@Config.LoadPolicy(Config.LoadType.MERGE)
+@Config.Sources({
+        "system:properties",
+        "classpath:database.properties",
+        "classpath:wp.properties"
+})
+public interface Configuration extends Config {
+
+    /**
+     * Wp username string.
+     * @return the string
+     */
+    @Key("wpUsername")
+    String wpUsername();
+
+    /**
+     * Wp password string.
+     * @return the string
+     */
+    @Key("wpPassword")
+    String wpPassword();
+
+    /**
+     * Wp url string.
+     * @return the string
+     */
+    @Key("wpUrl")
+    String wpUrl();
+
+    /**
+     * Url string.
+     * @return the string
+     */
+    @Key("url")
+    String url();
+
+    /**
+     * User string.
+     * @return the string
+     */
+    @Key("user")
+    String user();
+
+    /**
+     * Password string.
+     * @return the string
+     */
+    @Key("password")
+    String password();
+}

--- a/src/test/java/props/ConfigurationManager.java
+++ b/src/test/java/props/ConfigurationManager.java
@@ -1,0 +1,19 @@
+package props;
+
+import org.aeonbits.owner.ConfigCache;
+
+/** The type Configuration manager. */
+public final class ConfigurationManager {
+
+    private ConfigurationManager() {
+    }
+
+    /**
+     * Configuration configuration.
+     * @return the configuration
+     */
+    public static Configuration configuration() {
+        return ConfigCache.getOrCreate(Configuration.class);
+    }
+}
+

--- a/src/test/java/tests/ApiTest.java
+++ b/src/test/java/tests/ApiTest.java
@@ -1,0 +1,85 @@
+package tests;
+
+import io.qameta.allure.Severity;
+import io.qameta.allure.SeverityLevel;
+import io.qameta.allure.Story;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import pojo.Posts;
+
+import static db.DataBaseManager.getPost;
+
+import static wp.WordpressApiManager.createPost;
+import static wp.WordpressApiManager.deletePosts;
+import static wp.WordpressApiManager.updatePostTitle;
+
+/**
+ * The type Api test.
+ */
+public class ApiTest {
+
+    /**
+     * Field - id.
+     */
+    private int id;
+
+    /**
+     * Field - postTitle.
+     */
+    private final String postTitle = "createPostTitle";
+
+    /**
+     * Field - postContent.
+     */
+    private final String postContent = "createPostContent";
+
+    /**
+     * Create basic post.
+     */
+    @BeforeEach
+    public void createBasicPost()  {
+        id = createPost(postTitle, postContent)
+                .extract().path("id");
+    }
+
+    /**
+     * Change wp post title.
+     * @throws Exception the exception
+     */
+    @Story("Update wp post")
+    @Severity(SeverityLevel.NORMAL)
+    @Test
+    public void changeWpPostTitle() throws Exception {
+        String newTitle = "New Title";
+        updatePostTitle(id, newTitle)
+                .statusCode(200)
+                .assertThat()
+                .body("title.rendered", Matchers.equalTo(newTitle));
+        Posts posts = getPost(id);
+        Assertions.assertEquals(posts.getPostTitle(), newTitle,
+                "last post in database doesn't contain title 'New Title'");
+        Assertions.assertEquals(posts.getPostContent(), postContent,
+                "last post in database doesn't contain content 'createPostContent'");
+    }
+
+    /**
+     * Delete wp post content.
+     * @throws Exception the exception
+     */
+    @Story("Delete wp post")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void deleteWpPost() throws Exception {
+        deletePosts(id)
+                .statusCode(200)
+                .assertThat()
+                .body("status", Matchers.equalTo("trash"));
+        Posts posts = getPost(id);
+        Assertions.assertEquals(posts.getPostTitle(), postTitle,
+                "last post in database doesn't contain title 'createPostTitle'");
+        Assertions.assertEquals(posts.getStatus(), "trash",
+                "last post in database doesn't contain status 'trash'");
+    }
+}

--- a/src/test/java/tests/CreateTest.java
+++ b/src/test/java/tests/CreateTest.java
@@ -1,0 +1,44 @@
+package tests;
+
+import io.qameta.allure.Severity;
+import io.qameta.allure.SeverityLevel;
+import io.qameta.allure.Story;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import pojo.Posts;
+
+import static db.DataBaseManager.getPost;
+
+import static wp.WordpressApiManager.createPost;
+
+/**
+ * The type Create test.
+ */
+public class CreateTest {
+
+    /**
+     * Create wp post.
+     * @throws Exception the exception
+     */
+    @Story("Create wp post")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void createWpPost() throws Exception {
+        String postTitle = "createPostTitle";
+        String postContent = "createPostContent";
+        int id;
+        id = createPost(postTitle, postContent)
+                .statusCode(201)
+                .assertThat().body("title.rendered", Matchers.equalTo(postTitle))
+                .assertThat().body("content.rendered", Matchers.equalTo("<p>" + postContent + "</p>\n"))
+                .extract().path("id");
+        Posts posts = getPost(id);
+        Assertions.assertEquals(posts.getPostTitle(), "createPostTitle",
+                "last post in database doesn't contain title 'createPostTitle'");
+        Assertions.assertEquals(posts.getPostContent(), "createPostContent",
+                "last post in database doesn't contain content 'createPostContent'");
+        Assertions.assertEquals(posts.getStatus(), "publish",
+                "last post in database doesn't contain status 'publish'");
+    }
+}

--- a/src/test/java/utils/DataBaseConnection.java
+++ b/src/test/java/utils/DataBaseConnection.java
@@ -1,0 +1,27 @@
+package utils;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import static props.ConfigurationManager.configuration;
+
+/**
+ * The type Data base connection.
+ */
+public final class DataBaseConnection {
+
+    /**
+     * Create connection to database.
+     * @return the connection
+     * @throws SQLException the sql exception
+     */
+    public static Connection createConnection() throws SQLException {
+        return DriverManager.getConnection(configuration().url(),
+                configuration().user(), configuration().password());
+    }
+
+    private DataBaseConnection() {
+        throw new IllegalStateException("Utility class");
+    }
+}

--- a/src/test/java/wp/WordpressApiManager.java
+++ b/src/test/java/wp/WordpressApiManager.java
@@ -1,0 +1,92 @@
+package wp;
+
+import io.qameta.allure.Step;
+import io.qameta.allure.restassured.AllureRestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import org.json.JSONObject;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.preemptive;
+import static props.ConfigurationManager.configuration;
+
+/**
+ * The type Word press.
+ */
+public final class WordpressApiManager {
+
+    /**
+     * The constant URL.
+     */
+    private static final String URL = configuration().wpUrl();
+
+    /**
+     * The REQUEST_SPEC.
+     */
+    private static final RequestSpecification REQUEST_SPEC = new RequestSpecBuilder()
+            .setAuth(preemptive().basic(configuration().wpUsername(), configuration().wpPassword()))
+            .setBaseUri(URL)
+            .setContentType(ContentType.JSON)
+            .addFilter(new AllureRestAssured())
+            .build();
+
+    /**
+     * Delete posts validatable response.
+     * @param postID the post id
+     * @return the validatable response
+     */
+    @Step("delete post from WP")
+    public static ValidatableResponse deletePosts(final int postID) {
+        return given()
+                .spec(REQUEST_SPEC)
+                .queryParam("rest_route", "/wp/v2/posts/" + postID)
+                .when()
+                .delete()
+                .then();
+    }
+
+    /**
+     * Update post title validatable response.
+     * @param postID  the post id
+     * @param content the content
+     * @return the validatable response
+     */
+    @Step("update post in WP")
+    public static ValidatableResponse updatePostTitle(final int postID, final String content) {
+        JSONObject requestParams = new JSONObject();
+        requestParams.put("title", content);
+        return given()
+                .spec(REQUEST_SPEC)
+                .queryParam("rest_route", "/wp/v2/posts/" + postID)
+                .and()
+                .body(requestParams.toMap())
+                .when()
+                .patch()
+                .then();
+    }
+
+    /**
+     * Create post int.
+     * @param title   the title
+     * @param content the content
+     * @return the int
+     */
+    @Step("create post in WP")
+    public static ValidatableResponse createPost(final String title, final String content) {
+        return given()
+                .spec(REQUEST_SPEC)
+                .queryParam("rest_route", "/wp/v2/posts/")
+                .queryParam("title", title)
+                .queryParam("content", content)
+                .queryParam("status", "publish")
+                .when()
+                .post()
+                .then();
+    }
+
+    private WordpressApiManager() {
+        throw new IllegalStateException("Utility class");
+    }
+}

--- a/src/test/resources/database.properties
+++ b/src/test/resources/database.properties
@@ -1,0 +1,3 @@
+url=jdbc:mysql://localhost:3306/wordpress
+user=wordpress
+password=wordpress

--- a/src/test/resources/wp.properties
+++ b/src/test/resources/wp.properties
@@ -1,0 +1,3 @@
+wpUsername=Firstname.LastName
+wpPassword=123-Test-123
+wpUrl=http://localhost:8000/index.php

--- a/sun_checks_config.xml
+++ b/sun_checks_config.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+
+  Checkstyle configuration that checks the sun coding conventions from:
+
+    - the Java Language Specification at
+      https://docs.oracle.com/javase/specs/jls/se11/html/index.html
+
+    - the Sun Code Conventions at https://www.oracle.com/java/technologies/javase/codeconventions-contents.html
+
+    - the Javadoc guidelines at
+      https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html
+
+    - the JDK Api documentation https://docs.oracle.com/en/java/javase/11/
+
+    - some best practices
+
+  Checkstyle is very configurable. Be sure to read the documentation at
+  https://checkstyle.org (or in your downloaded distribution).
+
+  Most Checks are configurable, be sure to consult the documentation.
+
+  To completely disable a check, just comment it out or delete it from the file.
+  To suppress certain violations please review suppression filters.
+
+  Finally, it is worth reading the documentation.
+
+-->
+
+<module name="Checker">
+    <!--
+        If you set the basedir property below, then all reported file
+        names will be relative to the specified directory. See
+        https://checkstyle.org/config.html#Checker
+
+        <property name="basedir" value="${basedir}"/>
+    -->
+
+    <property name="severity" value="error"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+
+    <!-- Excludes all 'module-info.java' files              -->
+    <!-- See https://checkstyle.org/config_filefilters.html -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$"/>
+    </module>
+
+    <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${org.checkstyle.sun.suppressionfilter.config}"
+                  default="checkstyle-suppressions.xml" />
+        <property name="optional" value="true"/>
+    </module>
+
+    <!-- Checks that a package-info.java file exists for each package.     -->
+    <!-- See https://checkstyle.org/config_javadoc.html#JavadocPackage -->
+    <!--        <module name="JavadocPackage"/>-->
+
+    <!-- Checks whether files end with a new line.                        -->
+    <!-- See https://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->
+    <module name="NewlineAtEndOfFile"/>
+
+    <!-- Checks that property files contain the same keys.         -->
+    <!-- See https://checkstyle.org/config_misc.html#Translation -->
+    <module name="Translation"/>
+
+    <!-- Checks for Size Violations.                    -->
+    <!-- See https://checkstyle.org/config_sizes.html -->
+    <module name="FileLength"/>
+    <module name="LineLength">
+        <property name="fileExtensions" value="120"/>
+    </module>
+
+    <!-- Checks for whitespace                               -->
+    <!-- See https://checkstyle.org/config_whitespace.html -->
+    <module name="FileTabCharacter"/>
+
+    <!-- Miscellaneous other checks.                   -->
+    <!-- See https://checkstyle.org/config_misc.html -->
+    <module name="RegexpSingleline">
+        <property name="format" value="\s+$"/>
+        <property name="minimum" value="0"/>
+        <property name="maximum" value="0"/>
+        <property name="message" value="Line has trailing spaces."/>
+    </module>
+
+    <!-- Checks for Headers                                -->
+    <!-- See https://checkstyle.org/config_header.html   -->
+    <!-- <module name="Header"> -->
+    <!--   <property name="headerFile" value="${checkstyle.header.file}"/> -->
+    <!--   <property name="fileExtensions" value="java"/> -->
+    <!-- </module> -->
+
+    <module name="TreeWalker">
+
+        <!-- Checks for Javadoc comments.                     -->
+        <!-- See https://checkstyle.org/config_javadoc.html -->
+        <module name="InvalidJavadocPosition"/>
+        <module name="JavadocMethod"/>
+        <module name="JavadocType"/>
+        <module name="JavadocVariable"/>
+        <module name="JavadocStyle"/>
+        <module name="MissingJavadocMethod"/>
+
+        <!-- Checks for Naming Conventions.                  -->
+        <!-- See https://checkstyle.org/config_naming.html -->
+        <module name="ConstantName"/>
+        <module name="LocalFinalVariableName"/>
+        <module name="LocalVariableName"/>
+        <module name="MemberName"/>
+        <module name="MethodName"/>
+        <module name="PackageName"/>
+        <module name="ParameterName"/>
+        <module name="StaticVariableName"/>
+        <module name="TypeName"/>
+
+        <!-- Checks for imports                              -->
+        <!-- See https://checkstyle.org/config_imports.html -->
+        <module name="AvoidStarImport"/>
+        <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+        <module name="RedundantImport"/>
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="false"/>
+        </module>
+
+        <!-- Checks for Size Violations.                    -->
+        <!-- See https://checkstyle.org/config_sizes.html -->
+        <module name="MethodLength"/>
+        <module name="ParameterNumber"/>
+
+        <!-- Checks for whitespace                               -->
+        <!-- See https://checkstyle.org/config_whitespace.html -->
+        <module name="EmptyForIteratorPad"/>
+        <module name="GenericWhitespace"/>
+        <module name="MethodParamPad"/>
+        <module name="NoWhitespaceAfter"/>
+        <module name="NoWhitespaceBefore"/>
+        <module name="OperatorWrap"/>
+        <module name="ParenPad"/>
+        <module name="TypecastParenPad"/>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
+
+        <!-- Modifier Checks                                    -->
+        <!-- See https://checkstyle.org/config_modifier.html -->
+        <module name="ModifierOrder"/>
+        <module name="RedundantModifier"/>
+
+        <!-- Checks for blocks. You know, those {}'s         -->
+        <!-- See https://checkstyle.org/config_blocks.html -->
+        <module name="AvoidNestedBlocks"/>
+        <module name="EmptyBlock"/>
+        <module name="LeftCurly"/>
+        <module name="NeedBraces"/>
+        <module name="RightCurly"/>
+
+        <!-- Checks for common coding problems               -->
+        <!-- See https://checkstyle.org/config_coding.html -->
+        <module name="EmptyStatement"/>
+        <module name="EqualsHashCode"/>
+        <module name="HiddenField"/>
+        <module name="IllegalInstantiation"/>
+        <module name="InnerAssignment"/>
+        <module name="MagicNumber"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+
+        <!-- Checks for class design                         -->
+        <!-- See https://checkstyle.org/config_design.html -->
+        <module name="DesignForExtension"/>
+        <module name="FinalClass"/>
+        <module name="HideUtilityClassConstructor"/>
+        <module name="InterfaceIsType"/>
+        <module name="VisibilityModifier"/>
+
+        <!-- Miscellaneous other checks.                   -->
+        <!-- See https://checkstyle.org/config_misc.html -->
+        <module name="ArrayTypeStyle"/>
+        <module name="FinalParameters"/>
+        <module name="TodoComment"/>
+        <module name="UpperEll"/>
+
+        <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
+        <module name="SuppressionXpathFilter">
+            <property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}"
+                      default="checkstyle-xpath-suppressions.xml" />
+            <property name="optional" value="true"/>
+        </module>
+
+    </module>
+
+</module>


### PR DESCRIPTION
### UPD 4:
- удалён assert для createBasicPost() (ApiTest);

UPD 3:
- Getter, Setter,  AllArgsConstructor заменены на Data, удалены лишние конструкторы (pojo/);
- добавлено логгирование запросов/ответов в Allure-отчёт;
- данные для входа перенесены в конфиги;
- ренейминг;

UPD 2.1:
- добавлен lombok (java/pojo/);
- работа с idшником перенесена в queryParam (WordpressApiManager/deletePosts(), updatePostTitle()) ;

UPD 2:
- подключение к бд теперь статично (PostUtils);
- проверки на статус и содержания ответа перенесены в тесты;
- результат запроса к бд сохраняется в объекте;
- JsonProperty используется для переименования некоторых полей (Posts);
- немного ренейминга;
- обновлены тест-кейсы;

UPD 1.1:
- изменён способ формирования body (WordPress/updatePost())
- получение id нового поста реализовано через WP API (WordPress/createPost());
- изменена логика работы с БД (PostsUtils);

UPD 1:
- тест createWpPost вынесен в отдельный класс;;
- данные для подключения к БД вынесены в конфиги:
- добавлены методы для упрощения доступа к значениям из БД (PostUtils);
- класс для работы с WP API вынесен в отдельный пакет;
- добавлены проверки на статус и содержания ответа (WP/WordPress);
- базовая аутентификация перенесена в спецификацию (WordPress/REQUEST_SPEC);
- в тест-кейсы добавлены детали (ожидаемый код ответа, тело и т.п.);

UPD 0:
Добавлены:
- автотесты на создание/изменение/удаление постов (с проверкой изменений в БД) (test/java/tests);
- тест-кейсы (test/java/TestCases.txt);
- класс для работы с WP API (test/java/utils/WordPressUtils)
- класс для работы с постами, получаемыми из БД (test/java/utils/PostsUtils)
- pojo-объекты (test/java/pojo/);