### PR TITLE
feat: add bd/wp tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,11 +13,18 @@
         <maven.compiler.target>20</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectjweaver-version>1.9.19</aspectjweaver-version>
-        <allure-junit5-version>2.22.0</allure-junit5-version>
+        <allure-junit5-version>2.22.2</allure-junit5-version>
         <maven-resources-plugin-version>3.3.1</maven-resources-plugin-version>
         <maven-compiler-plugin-version>3.11.0</maven-compiler-plugin-version>
-        <maven-surefire-plugin-version>3.1.0</maven-surefire-plugin-version>
+        <maven-surefire-plugin-version>3.1.2</maven-surefire-plugin-version>
         <junit-jupiter-version>5.10.0-M1</junit-jupiter-version>
+        <mysql-connector-j-version>8.0.33</mysql-connector-j-version>
+        <slf4j-simple-version>2.0.7</slf4j-simple-version>
+        <jackson-databind-version>2.15.2</jackson-databind-version>
+        <rest-assured-version>5.3.1</rest-assured-version>
+        <json-version>20230227</json-version>
+        <owner-version>1.0.12</owner-version>
+        <lombok-version>1.18.28</lombok-version>
     </properties>
 
     <dependencies>
@@ -26,14 +33,14 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>8.0.33</version>
+            <version>${mysql-connector-j-version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.7</version>
+            <version>${slf4j-simple-version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -41,7 +48,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.10.0-M1</version>
+            <version>${junit-jupiter-version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -49,14 +56,14 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.0-rc2</version>
+            <version>${jackson-databind-version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.rest-assured/rest-assured -->
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>5.3.0</version>
+            <version>${rest-assured-version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -64,7 +71,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20230227</version>
+            <version>${json-version}</version>
         </dependency>
 
         <dependency>
@@ -91,14 +98,14 @@
         <dependency>
             <groupId>org.aeonbits.owner</groupId>
             <artifactId>owner</artifactId>
-            <version>1.0.12</version>
+            <version>${owner-version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.28</version>
+            <version>${lombok-version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -108,7 +115,6 @@
             <artifactId>allure-rest-assured</artifactId>
             <version>${allure-junit5-version}</version>
         </dependency>
-
 
     </dependencies>
 
@@ -130,7 +136,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.28</version>
+                            <version>${lombok-version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/src/test/java/TestCases.txt
+++ b/src/test/java/TestCases.txt
@@ -1,7 +1,7 @@
 id: createWpPost
 Заголовок: создать пост
 Шаги:
-1. отправить POST-запрос на /wp/v2/posts, установив query-параметры title - createPostTitle, content - createPostContent, status - publish
+1. отправить POST-запрос на /wp/v2/posts, установив query-параметры title - "createPostTitle", content - "createPostContent", status - "publish"
 Ожидаемый результат:
 1. код ответа равен 201
 2. тело ответа в формате JSON возращается от сервера и имеет следующий вид (... - любые ключи/значения, перечисленные ключи являются обязательными):
@@ -24,9 +24,9 @@ id: createWpPost
 id: changeWpPostTitle
 Заголовок: изменить заголовок поста
 Предусловие:
-1. отправить POST-запрос на /wp/v2/posts, установив query-параметры title - createPostTitle, content - createPostContent, status - publish
+1. отправить INSERT-запрос к таблице wp_posts (БД - wordpress), передав параметры title - "createPostTitle", content - "createPostContent", status - "publish"
 Шаги:
-1. отправить PATCH-запрос на /wp/v2/posts/{postId} (postId - ID поста, созданного в предусловии), передав в body запроса title - New Title
+1. отправить PATCH-запрос на /wp/v2/posts/{postId} (postId - ID поста, созданного в предусловии), передав в body запроса title - "New Title"
 Ожидаемый результат:
 1. код ответа равен 200
 2. тело ответа в формате JSON возращается от сервера и имеет следующий вид (... - любые ключи/значения, перечисленные ключи являются обязательными):
@@ -44,12 +44,12 @@ id: changeWpPostTitle
     },
     ...
 }
-3. в таблице wp_posts (БД - wordpress)  появилась и обновилась запись, содержащая (после обновления) post_title "New Title", post_content "createPostContent"
+3. в таблице wp_posts (БД - wordpress) появилась и обновилась запись, содержащая (после обновления) post_title "New Title", post_content "createPostContent"
 
 id: deleteWpPost
 Заголовок: удалить пост
 Предусловие:
-1. отправить POST-запрос на /wp/v2/posts, установив query-параметры title - createPostTitle, content - createPostContent, status - publish
+1. отправить INSERT-запрос к таблице wp_posts (БД - wordpress), передав параметры title - "createPostTitle", content - "createPostContent", status - "publish"
 Шаги:
 1. отправить DELETE-запрос на /wp/v2/posts/{postId} (postId - ID поста, созданного в предусловии)
 Ожидаемый результат:
@@ -70,3 +70,12 @@ id: deleteWpPost
     ...
 }
 3. в таблице wp_posts (БД - wordpress)  появилась и обновилась запись, содержащая (после обновления) post_title "createPostTitle, status "trash"
+
+id: getWpPost
+Заголовок: получить пост после его создания в БД через WP API
+Предусловие:
+1. отправить INSERT-запрос к таблице wp_posts (БД - wordpress), передав параметры title - "createPostTitle", content - "createPostContent", status - "publish"
+Шаги:
+2. отправить GET-запрос на /wp/v2/posts/{postId} (postId - ID поста, созданного в шаге 1)
+Ожидаемый результат:
+1. в ответе о WP API запись содержит post_title "createPostTitle, post_content "createPostContent", status "publish"

--- a/src/test/java/db/DataBaseManager.java
+++ b/src/test/java/db/DataBaseManager.java
@@ -2,31 +2,34 @@ package db;
 
 import pojo.Posts;
 
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.ResultSet;
+import java.sql.PreparedStatement;
+import java.sql.Connection;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
 import static utils.DataBaseConnection.createConnection;
 
 /**
- * The type Posts utils.
+ * The type Data base manager.
  */
 public final class DataBaseManager {
 
     /**
-     * Gets posts.
+     * Gets post data from db.
      * @param id the id
-     * @return Posts
-     * @throws SQLException the sql exception
+     * @return the post data from db
      */
-    public static List<Posts> getPostDataFromDB(final int id) throws SQLException {
-        ResultSet resultSet = null;
+    public static List<Posts> getPostDataFromDB(final int id) {
+        ResultSet resultSet;
         List<Posts> list = new ArrayList<Posts>();
         String query = "SELECT * FROM wp_posts WHERE ID = ?";
         Posts posts;
-        try (PreparedStatement statement = createConnection().prepareStatement(query)) {
+        PreparedStatement statement;
+        try (Connection connection = createConnection()) {
+            statement = connection.prepareStatement(query);
             statement.setInt(1, id);
             resultSet = statement.executeQuery();
             while (resultSet.next()) {
@@ -37,22 +40,72 @@ public final class DataBaseManager {
                 posts.setPostTitle(resultSet.getString("post_title"));
                 list.add(posts);
             }
-        } finally {
-            assert resultSet != null;
             resultSet.close();
-            createConnection().close();
+            statement.close();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
         }
         return list;
     }
 
     /**
-     * Gets posts.
+     * Gets post.
      * @param id the id
-     * @return Posts
-     * @throws SQLException the sql exception
+     * @return the post
      */
-    public static Posts getPost(final int id) throws SQLException {
+    public static Posts getPost(final int id) {
         return getPostDataFromDB(id).get(0);
+    }
+
+    /**
+     * Create post in db int.
+     * @param title   the title
+     * @param content the content
+     * @return the int
+     */
+    public static int createPostInDB(final String title, final String content) {
+        int insertPostID = 0;
+        String query = "INSERT wordpress.wp_posts (post_author, post_date, " +
+                "post_date_gmt, post_content," +
+                "post_title, post_excerpt, " +
+                "post_status, to_ping, pinged, " +
+                "post_modified, post_modified_gmt, " +
+                "post_content_filtered) " +
+                "VALUES (1, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), ?, ?, '', 'publish', '', '', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), '')";
+        ResultSet generatedKeyResult;
+        PreparedStatement statement;
+        try (Connection connection = createConnection()) {
+            statement = connection.prepareStatement(query, Statement.RETURN_GENERATED_KEYS);
+            statement.setString(1, content);
+            statement.setString(2, title);
+            statement.executeUpdate();
+            generatedKeyResult = statement.getGeneratedKeys();
+            if (generatedKeyResult.next()) {
+                insertPostID = generatedKeyResult.getInt(1);
+                generatedKeyResult.close();
+            }
+            statement.close();
+            generatedKeyResult.close();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return insertPostID;
+    }
+
+
+    /**
+     * Delete all created post in db.
+     */
+    public static void deleteAllPosts() {
+        String query = "TRUNCATE wp_posts";
+        PreparedStatement statement;
+        try (Connection connection = createConnection()) {
+            statement = connection.prepareStatement(query);
+            statement.executeUpdate();
+            statement.close();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private DataBaseManager() {

--- a/src/test/java/pojo/Posts.java
+++ b/src/test/java/pojo/Posts.java
@@ -32,4 +32,30 @@ public class Posts {
      */
     @JsonProperty("post_content")
     private String postContent;
+
+    /**
+     * Gets content.
+     * @return the content
+     */
+    public Content getContent() {
+        return content;
+    }
+
+    /**
+     * The Content.
+     */
+    private Content content;
+
+    /**
+     * Gets title.
+     * @return the title
+     */
+    public Title getTitle() {
+        return title;
+    }
+
+    /**
+     * The Title.
+     */
+    private Title title;
 }

--- a/src/test/java/props/Config.java
+++ b/src/test/java/props/Config.java
@@ -1,17 +1,16 @@
 package props;
 
-import org.aeonbits.owner.Config;
-
 /**
  * The interface Configuration.
  */
-@Config.LoadPolicy(Config.LoadType.MERGE)
-@Config.Sources({
+@org.aeonbits.owner.Config.LoadPolicy(org.aeonbits.owner.Config.LoadType.MERGE)
+@org.aeonbits.owner.Config.Sources({
         "system:properties",
         "classpath:database.properties",
-        "classpath:wp.properties"
+        "classpath:wp.properties",
+        "classpath:testData.properties",
 })
-public interface Configuration extends Config {
+public interface Config extends org.aeonbits.owner.Config {
 
     /**
      * Wp username string.
@@ -54,4 +53,26 @@ public interface Configuration extends Config {
      */
     @Key("password")
     String password();
+
+    /**
+     * Post title string.
+     * @return the string
+     */
+    @Key("postTitle")
+    String postTitle();
+
+    /**
+     * Post content string.
+     * @return the string
+     */
+    @Key("postContent")
+    String postContent();
+
+    /**
+     * New post title string.
+     * @return the string
+     */
+    @Key("newPostTitle")
+    String newPostTitle();
+
 }

--- a/src/test/java/props/ConfigurationManager.java
+++ b/src/test/java/props/ConfigurationManager.java
@@ -12,8 +12,8 @@ public final class ConfigurationManager {
      * Configuration configuration.
      * @return the configuration
      */
-    public static Configuration configuration() {
-        return ConfigCache.getOrCreate(Configuration.class);
+    public static Config config() {
+        return ConfigCache.getOrCreate(Config.class);
     }
 }
 

--- a/src/test/java/tests/ApiTest.java
+++ b/src/test/java/tests/ApiTest.java
@@ -2,18 +2,21 @@ package tests;
 
 import io.qameta.allure.Severity;
 import io.qameta.allure.SeverityLevel;
+import io.qameta.allure.Step;
 import io.qameta.allure.Story;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import pojo.Posts;
 
+import static db.DataBaseManager.createPostInDB;
 import static db.DataBaseManager.getPost;
+import static db.DataBaseManager.deleteAllPosts;
 
-import static wp.WordpressApiManager.createPost;
-import static wp.WordpressApiManager.deletePosts;
-import static wp.WordpressApiManager.updatePostTitle;
+import static props.ConfigurationManager.config;
+import static wp.WordpressApiManager.*;
 
 /**
  * The type Api test.
@@ -21,65 +24,76 @@ import static wp.WordpressApiManager.updatePostTitle;
 public class ApiTest {
 
     /**
-     * Field - id.
+     * Field - postID.
      */
-    private int id;
-
-    /**
-     * Field - postTitle.
-     */
-    private final String postTitle = "createPostTitle";
-
-    /**
-     * Field - postContent.
-     */
-    private final String postContent = "createPostContent";
+    private int postID;
 
     /**
      * Create basic post.
      */
     @BeforeEach
-    public void createBasicPost()  {
-        id = createPost(postTitle, postContent)
-                .extract().path("id");
+    @Step("create basic post")
+    public void createBasicPost() {
+        postID = createPostInDB(config().postTitle(), config().postContent());
     }
 
     /**
      * Change wp post title.
-     * @throws Exception the exception
      */
     @Story("Update wp post")
     @Severity(SeverityLevel.NORMAL)
     @Test
-    public void changeWpPostTitle() throws Exception {
-        String newTitle = "New Title";
-        updatePostTitle(id, newTitle)
+    public void changeWpPostTitle() {
+        updatePostTitle(postID, config().newPostTitle())
                 .statusCode(200)
                 .assertThat()
-                .body("title.rendered", Matchers.equalTo(newTitle));
-        Posts posts = getPost(id);
-        Assertions.assertEquals(posts.getPostTitle(), newTitle,
-                "last post in database doesn't contain title 'New Title'");
-        Assertions.assertEquals(posts.getPostContent(), postContent,
-                "last post in database doesn't contain content 'createPostContent'");
+                .body("title.rendered", Matchers.equalTo(config().newPostTitle()));
+        Posts posts = getPost(postID);
+        Assertions.assertEquals(posts.getPostTitle(), config().newPostTitle(),
+                "last post in database doesn't contain title " + config().newPostTitle());
+        Assertions.assertEquals(posts.getPostContent(), config().postContent(),
+                "last post in database doesn't contain content " + config().postContent());
     }
 
     /**
      * Delete wp post content.
-     * @throws Exception the exception
      */
     @Story("Delete wp post")
-    @Severity(SeverityLevel.CRITICAL)
+    @Severity(SeverityLevel.NORMAL)
     @Test
-    public void deleteWpPost() throws Exception {
-        deletePosts(id)
+    public void deleteWpPost() {
+        deletePosts(postID)
                 .statusCode(200)
                 .assertThat()
                 .body("status", Matchers.equalTo("trash"));
-        Posts posts = getPost(id);
-        Assertions.assertEquals(posts.getPostTitle(), postTitle,
-                "last post in database doesn't contain title 'createPostTitle'");
+        Posts posts = getPost(postID);
+        Assertions.assertEquals(posts.getPostTitle(), config().postTitle(),
+                "last post in database doesn't contain title " + config().postTitle());
         Assertions.assertEquals(posts.getStatus(), "trash",
                 "last post in database doesn't contain status 'trash'");
+    }
+
+    /**
+     * Read wp post.
+     */
+    @Story("Get wp post")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void getWpPost() {
+        Posts posts = readPost(postID);
+        Assertions.assertEquals(config().postTitle(), posts.getTitle().getRendered(),
+                "new post in WP doesn't contain title " + config().postTitle());
+        Assertions.assertEquals("<p>" + config().postContent() + "</p>\n", posts.getContent().getRendered(),
+                "new post in WP doesn't contain content " + config().postContent());
+        Assertions.assertEquals("publish", posts.getStatus(),
+                "new post in WP doesn't contain status 'publish'");
+    }
+
+    /**
+     * Delete created posts.
+     */
+    @AfterAll
+    public static void deleteCreatedPosts() {
+        deleteAllPosts();
     }
 }

--- a/src/test/java/tests/CreateTest.java
+++ b/src/test/java/tests/CreateTest.java
@@ -4,13 +4,16 @@ import io.qameta.allure.Severity;
 import io.qameta.allure.SeverityLevel;
 import io.qameta.allure.Story;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import pojo.Posts;
 
 import static db.DataBaseManager.getPost;
-
+import static db.DataBaseManager.deleteAllPosts;
 import static wp.WordpressApiManager.createPost;
+
+import static props.ConfigurationManager.config;
 
 /**
  * The type Create test.
@@ -19,26 +22,31 @@ public class CreateTest {
 
     /**
      * Create wp post.
-     * @throws Exception the exception
      */
     @Story("Create wp post")
     @Severity(SeverityLevel.CRITICAL)
     @Test
-    public void createWpPost() throws Exception {
-        String postTitle = "createPostTitle";
-        String postContent = "createPostContent";
-        int id;
-        id = createPost(postTitle, postContent)
+    public void createWpPost() {
+        int postID;
+        postID = createPost(config().postTitle(), config().postContent())
                 .statusCode(201)
-                .assertThat().body("title.rendered", Matchers.equalTo(postTitle))
-                .assertThat().body("content.rendered", Matchers.equalTo("<p>" + postContent + "</p>\n"))
+                .assertThat().body("title.rendered", Matchers.equalTo(config().postTitle()))
+                .assertThat().body("content.rendered", Matchers.equalTo("<p>" + config().postContent() + "</p>\n"))
                 .extract().path("id");
-        Posts posts = getPost(id);
-        Assertions.assertEquals(posts.getPostTitle(), "createPostTitle",
-                "last post in database doesn't contain title 'createPostTitle'");
-        Assertions.assertEquals(posts.getPostContent(), "createPostContent",
-                "last post in database doesn't contain content 'createPostContent'");
+        Posts posts = getPost(postID);
+        Assertions.assertEquals(posts.getPostTitle(), config().postTitle(),
+                "last post in database doesn't contain title " + config().postTitle());
+        Assertions.assertEquals(posts.getPostContent(), config().postContent(),
+                "last post in database doesn't contain content " + config().postContent());
         Assertions.assertEquals(posts.getStatus(), "publish",
                 "last post in database doesn't contain status 'publish'");
+    }
+
+    /**
+     * Delete created posts.
+     */
+    @AfterAll
+    public static void deleteCreatedPosts() {
+        deleteAllPosts();
     }
 }

--- a/src/test/java/utils/DataBaseConnection.java
+++ b/src/test/java/utils/DataBaseConnection.java
@@ -4,7 +4,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
-import static props.ConfigurationManager.configuration;
+import static props.ConfigurationManager.config;
 
 /**
  * The type Data base connection.
@@ -17,8 +17,8 @@ public final class DataBaseConnection {
      * @throws SQLException the sql exception
      */
     public static Connection createConnection() throws SQLException {
-        return DriverManager.getConnection(configuration().url(),
-                configuration().user(), configuration().password());
+        return DriverManager.getConnection(config().url(),
+                config().user(), config().password());
     }
 
     private DataBaseConnection() {

--- a/src/test/java/wp/WordpressApiManager.java
+++ b/src/test/java/wp/WordpressApiManager.java
@@ -7,10 +7,11 @@ import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 import org.json.JSONObject;
+import pojo.Posts;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.preemptive;
-import static props.ConfigurationManager.configuration;
+import static props.ConfigurationManager.config;
 
 /**
  * The type Word press.
@@ -20,13 +21,13 @@ public final class WordpressApiManager {
     /**
      * The constant URL.
      */
-    private static final String URL = configuration().wpUrl();
+    private static final String URL = config().wpUrl();
 
     /**
      * The REQUEST_SPEC.
      */
     private static final RequestSpecification REQUEST_SPEC = new RequestSpecBuilder()
-            .setAuth(preemptive().basic(configuration().wpUsername(), configuration().wpPassword()))
+            .setAuth(preemptive().basic(config().wpUsername(), config().wpPassword()))
             .setBaseUri(URL)
             .setContentType(ContentType.JSON)
             .addFilter(new AllureRestAssured())
@@ -84,6 +85,22 @@ public final class WordpressApiManager {
                 .when()
                 .post()
                 .then();
+    }
+
+    /**
+     * Read wp post posts.
+     * @param postID the post id
+     * @return the posts
+     */
+    @Step("read WP post")
+    public static Posts readPost(final int postID) {
+        return given()
+                .spec(REQUEST_SPEC)
+                .queryParam("rest_route", "/wp/v2/posts/" + postID)
+                .when()
+                .patch()
+                .then()
+                .extract().as(Posts.class);
     }
 
     private WordpressApiManager() {

--- a/src/test/resources/testData.properties
+++ b/src/test/resources/testData.properties
@@ -1,0 +1,3 @@
+postTitle=createPostTitle
+postContent=createPostContent
+newPostTitle=New Title


### PR DESCRIPTION
### UPD4:
- getWpPost() перенесён в ApiTest

UPD 3:
тесты, тест-кейсы:
- удалены дублирующиеся тесты;

UPD 2:
- методы удаления по id/статусу заменены на очищение всей таблицы (DataBaseManager);
- ренейминг;

UPD 1:
TestCases.txt: 
- обновлены предусловия для changeWpPostTitle, deleteWpPost (теперь пост создаётся через БД, а не WP API);
- обновлены id и заголовки для ex- readWpPost, updatePostInDBTest, deletePostInDBTest;

DataBaseManager.java:
- для методов взаимодействия с БД добавлено закрытие Connection;
- удалёно получение id постов для последующего удаления;
- добавлен метод для удаления постов со статусом "inherit" (побочный продукт изменения постов);

Тесты:
- @BeforeEach 1) создаёт пост через БД 2) собирает id созданных постов
- тестовые данные (postTitle, postContent, etc.) перенесены в testData.properties;
- объединены в один пакет;
- обновлены названия/аннотации;

UPD 0.1:
- добавлены allure-аннотации в тесты;
- обновлены версии зависимостей в pom;

UPD 0:
Добавлены:
- тест-кейсы на проверку получения данных через api запрос (TestCases.txt);
- автотоесты по тест-кейсам (java.tests.db);
- методы на запись/обновление/удаление записей в БД (DataBaseManager);
- метод на чтение записей из WP (WordpressApiManager);